### PR TITLE
Optimize provision script; use pwntools

### DIFF
--- a/provision.sh
+++ b/provision.sh
@@ -146,7 +146,8 @@ init() {
         ipython ipython3
 
     # Install 32 bit libs
-    package libc6:i386 libncurses5:i386 libstdc++6:i386 \
+    package \
+        libc6:i386 libncurses5:i386 libstdc++6:i386 \
         libc6-dbg libc6-dbg:i386 \
         libc6-dev-i386
 

--- a/provision.sh
+++ b/provision.sh
@@ -57,7 +57,7 @@ install_pwndbg() {
     if ! grep pwndbg ~/.gdbinit &>/dev/null; then
         echo "# source $HOMEDIR/tools/pwndbg/gdbinit.py" >> ~/.gdbinit
     fi
-    git_clone https://github.com/zachriggle/pwndbg pwndbg
+    git_clone https://github.com/pwndbg/pwndbg.git pwndbg
     cd pwndbg
     ./setup.sh
 }


### PR DESCRIPTION
Binjitsu has been merged back to pwntools, so the provision script
installs pwntools instead. There are also some optimizations:
- Reduce the number of times `apt-get update` is called
- Run make in parallel (`-j` switch)

This change also makes the provision script idempotent so that it can be
run multiple times.
